### PR TITLE
URLs to the resources inside jar files should not have // (double slash)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # [One-JAR™](http://one-jar.sourceforge.net)
-One-JAR is a tool to package a Java application with its dependency jars into a single jar file.
+[One-JAR™](http://one-jar.sourceforge.net) is a tool to package a Java application with its dependency jars into a single jar file.
 
 # What is One-JAR-Boot?
 `one-jar-boot` is The low-level JarClassLoader and other One-JAR bootstrap mechanisms Contains source-code for the One-JAR bootstrap classes ([The description from the One-JAR web site](http://one-jar.sourceforge.net/index.php?page=downloads&file=downloads)).

--- a/build.gradle
+++ b/build.gradle
@@ -7,6 +7,12 @@ version = '0.9.7-ex1'
 sourceCompatibility = 1.6
 targetCompatibility = 1.6
 
+//gradle.projectsEvaluated {
+//  tasks.withType(JavaCompile) {
+//    options.compilerArgs << "-Xlint:unchecked" << "-Xlint:deprecation"
+//  }
+//}
+
 jar {
   manifest {
     attributes 'Implementation-Title': 'One Jar Boot',

--- a/src/main/java/com/simontuffs/onejar/Boot.java
+++ b/src/main/java/com/simontuffs/onejar/Boot.java
@@ -182,7 +182,7 @@ public class Boot {
     if (Boolean.valueOf(System.getProperty(P_SHOW_PROPERTIES, "false")).booleanValue()) {
       // What are the system properties.
       Properties props = System.getProperties();
-      String keys[] = props.keySet().toArray(new String[]{});
+      String keys[] = props.keySet().toArray(new String[0]);
       Arrays.sort(keys);
 
       for (int i = 0; i < keys.length; i++) {
@@ -251,7 +251,7 @@ public class Boot {
       } else {
         // There is no main jar. Info unless mainJar is empty string.
         // The load(mainClass) will scan for main jars anyway.
-        if (!"".equals(mainJar)) {
+        if (mainJar != null && !mainJar.isEmpty()) {
           LOGGER.info("Unable to locate main jar '" + mainJar + "' in the JAR file " + getMyJarPath());
         }
       }

--- a/src/main/java/com/simontuffs/onejar/IoUtils.java
+++ b/src/main/java/com/simontuffs/onejar/IoUtils.java
@@ -1,0 +1,51 @@
+package com.simontuffs.onejar;
+
+import java.io.*;
+
+/**
+ * @author Lee, SeongHyun (Kevin)
+ * @version 0.0.1 (15/02/2015)
+ */
+public final class IoUtils {
+  private final static Logger LOGGER = Logger.getLogger("IoUtils");
+
+  private IoUtils() throws IllegalAccessException {
+    throw new IllegalAccessException(IoUtils.class.getName() + " cannot be instantiated.");
+  }
+
+  /**
+   * Closes the given closeable without throwing any exception if it is not null.
+   * If it throws any exception, logs it but doesn't re-throw it.
+   *
+   * @param closeable Closeable to be closed.
+   */
+  public static void closeQuietly(final Closeable closeable) {
+    if (closeable != null) {
+      try {
+        closeable.close();
+      } catch (Exception e) {
+        final StringWriter out = new StringWriter();
+        final PrintWriter writer = new PrintWriter(out);
+        e.printStackTrace(writer);
+        LOGGER.warning(out.toString());
+      }
+    }
+  }
+
+  /**
+   * Utility to assist with copying InputStream to OutputStream.  All
+   * bytes are copied, but both streams are left open.
+   *
+   * @param in  Source of bytes to copy.
+   * @param out Destination of bytes to copy.
+   * @throws IOException
+   */
+  public static void copy(final InputStream in, OutputStream out) throws IOException {
+    final byte[] buf = new byte[1024];
+    int len = in.read(buf);
+    while (len >= 0) {
+      out.write(buf, 0, len);
+      len = in.read(buf);
+    }
+  }
+}

--- a/src/main/java/com/simontuffs/onejar/OneJarURLConnection.java
+++ b/src/main/java/com/simontuffs/onejar/OneJarURLConnection.java
@@ -25,12 +25,13 @@ public class OneJarURLConnection extends JarURLConnection {
 
   private JarFile jarFile;
 
-  private static URL removeDoubleSlashesAfterBang(URL url) throws MalformedURLException {
+  private static URL fromBangDoubleSlashToBangSlash(URL url) throws MalformedURLException {
     return new URL(url.getProtocol(), url.getHost(), url.getPort(), url.getFile().replaceAll("!//", "!/"));
   }
 
   public OneJarURLConnection(URL url) throws MalformedURLException {
-    super(removeDoubleSlashesAfterBang(url));
+//    super(fromBangDoubleSlashToBangSlash(url));
+    super(url);
   }
 
   public JarFile getJarFile() throws IOException {


### PR DESCRIPTION
- #1 - URLs to the resources inside jar files should not have // (double slash) [Issue #1](https://github.com/Kevin-Lee/one-jar-boot/issues/1)
- URL for resource inside jar no longer has !// when OneJarURLConnection is created. It's now handled properly by JarClassLoader.
- refactored
