### PR TITLE
one-jar-boot v0.97.4

### DIFF
--- a/changelogs/0.97.3.md
+++ b/changelogs/0.97.3.md
@@ -1,0 +1,12 @@
+## [v0.97.3](https://github.com/Kevin-Lee/one-jar-boot/issues?q=is%3Aissue+milestone%3Amilestone1+is%3Aclosed) - 2015-08-27
+
+## Fixed
+* URLs to the resources inside jar files should not have `//` (double slash) (#1)
+  
+  URLs to the resources inside jar files should not have `//` (double slash).
+  When One-JAR forms the URL for the resources inside a jar file, It seems
+  * it prepends `/` to the filename or
+  * the filename already has it but it doesn't trim it properly.
+  
+  Either way, a quick fix might be replacing all `!//` with `!/` in a resource URL when [OneJarURLConnection](/Kevin-Lee/one-jar-boot/blob/90ad7f7f4979dfd7074fa5e7ceffbff6a8684099/src/main/java/com/simontuffs/onejar/OneJarURLConnection.java#L28) is created with the resource URL.
+* Should be artifactId "workspace" instead of one-jar-boot (#3)

--- a/changelogs/0.97.4.md
+++ b/changelogs/0.97.4.md
@@ -1,0 +1,6 @@
+## [v0.97.4](https://github.com/Kevin-Lee/one-jar-boot/issues?q=is%3Aissue+milestone%3Amilestone2+is%3Aclosed) - 2021-08-14
+
+## Done
+* Convert `one-jar-boot` to an sbt project to easily publish to Maven Central (#6)
+* Add the `LICENSE` file from the original one-jar project (#9)
+* Include `.version` file in the packaged jar (#13)


### PR DESCRIPTION
# one-jar-boot v0.97.4
## [v0.97.4](https://github.com/Kevin-Lee/one-jar-boot/issues?q=is%3Aissue+milestone%3Amilestone2+is%3Aclosed) - 2021-08-14

## Done
* Convert `one-jar-boot` to an sbt project to easily publish to Maven Central (#6)
* Add the `LICENSE` file from the original one-jar project (#9)
* Include `.version` file in the packaged jar (#13)
